### PR TITLE
Add Senior Engineering Manager role

### DIFF
--- a/packages/app/public/locales/en/translation.json
+++ b/packages/app/public/locales/en/translation.json
@@ -5,7 +5,7 @@
   "section_work": "Work Experience",
   "welcome": "Welcome to my personal webspace.",
   "intro-part1": "Engineering leader based in the SF Bay Area with 10+ years of experience building and scaling enterprise SaaS products, and 2+ years leading high-performing engineering teams. I like to be the GPS for engineers guiding them in their career journey. I’m deeply motivated by helping engineers grow, finding the intersection of what they’re good at, what they like, and where they want to go, and turning that into meaningful career progress and strong team outcomes.",
-  "intro-part2": " Currently I am an Engineering Manager at Okta leading a group comprised of 4 teams. My group leads horizontal UI platform modernization and global design system adoption initiatives to deliver unified, accessible user experiences, partnered with product/design for our customers",
+  "intro-part2": " Currently I am a Senior Engineering Manager at Okta leading a group comprised of 4 teams across 3 continents. My group leads horizontal UI platform modernization and global design system adoption initiatives to deliver unified, accessible user experiences, partnered with product/design for our customers",
   "intro-part3": " My other interests include following a lot of European football (soccer) supporting <1>#mufc</1>. I try and play (on field & x-box) whenever I get a chance. I currently live in the San Francisco, Bay Area with my wife, our son and our dog <2> Mowgli </2>",
   "footer":"Thanks for visiting."
 }

--- a/packages/app/src/data/data.json
+++ b/packages/app/src/data/data.json
@@ -1,7 +1,7 @@
 {
   "basics": {
     "name": "Nikhil Venkatraman",
-    "label": "Engineering Manager \u2022 UI Platform & Design Systems",
+    "label": "Senior Engineering Manager \u2022 UI Platform & Design Systems",
     "location": {
       "region": "SF Bay Area",
       "country": "USA"
@@ -21,16 +21,26 @@
       }
     ]
   },
-  "summary": "Engineering manager and design systems leader with 10+ years building and scaling enterprise SaaS. Led UI platform modernization and global design system adoption to deliver unified, accessible user experiences; partnered with product/design to accelerate delivery, cut costs, and improve global adoption.",
+  "summary": "Engineering leader with 10+ years building UI platforms and design systems for enterprise SaaS. Currently leading Okta's UI Platform & Design Systems org as Senior Engineering Manager (16 engineers across 4 teams, incl. 1 EM), enabling 30+ product teams to ship consistent, accessible, global experiences faster. Platform-as-product operator focused on developer experience and reliability.",
   "experience": [
     {
       "company": "Okta, Inc.",
       "location": "San Francisco, CA",
       "positions": [
         {
+          "title": "Senior Engineering Manager – UI Platform & Design Systems",
+          "start": "2026-04",
+          "end": null,
+          "highlights": [
+            "Expanding UI Platform org globally by establishing an India engineering hub, scaling distributed capacity across 3 continents to accelerate platform delivery.",
+            "Evangelizing a UI Gold Standard tech stack across all new product development, mandating adoption of Odyssey design system, globalization-ready architecture, accessibility compliance, and Okta's latest UI framework — establishing consistent engineering standards across product orgs.",
+            "Driving AI-powered rapid prototyping capabilities for PM and Design, enabling product teams to generate high-fidelity prototypes directly from Odyssey design system components, reducing time from concept to validated UI."
+          ]
+        },
+        {
           "title": "Engineering Manager – UI Platform & Design Systems",
           "start": "2024-02",
-          "end": null,
+          "end": "2026-04",
           "highlights": [
             "Lead a centralized UI Platform organization to standardize front-end architecture and design-system foundations across Okta's acquired and core products, enabling faster integration of newly acquired product surfaces.",
             "Lead and scale distributed org of 16 engineers (US & Canada) across 4 teams; 1 EM; responsible for hiring, performance, and org design.",


### PR DESCRIPTION
## Summary
- Added new Senior Engineering Manager – UI Platform & Design Systems role (Apr 2026–Present) with highlights
- Updated Engineering Manager role end date to Apr 2026
- Updated page title/label and About section bio to reflect promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)